### PR TITLE
fix: Coverage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       all: true,
+      include: ['src'],
     },
     css: {
       modules: {


### PR DESCRIPTION
Only collect code coverage from `src` folder